### PR TITLE
feat: add /predict endpoint; feat: implement MNIST model inference logic; fix: validate input shape and type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,8 +858,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "ndarray",
  "ort",
  "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -1088,6 +1091,26 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ anyhow = "1.0.98"
 ort = "2.0.0-rc.9"
 serde = { version = "1.0.219", features = ["derive"] }
 async-trait = "0.1.88"
+thiserror = "2.0.12"
+serde_json = "1.0.140"
+ndarray = "0.16.1"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,23 @@
+use crate::errors::DomainError;
+use crate::inference::Inference;
+use crate::models::{Features, Prediction};
+use axum::http::StatusCode;
+use axum::routing::post;
+use axum::{Extension, Json};
+use ort::value::Tensor;
+use std::sync::Arc;
+
+async fn predict(
+    Extension(inference): Extension<Arc<dyn Inference>>,
+    Json(features): Json<Features>,
+) -> Result<(StatusCode, Json<Prediction>), DomainError> {
+    let inputs: Tensor<f32> = features.try_into()?;
+    let outputs = inference.infer(inputs).await?;
+    Ok((StatusCode::OK, Json(outputs.try_into()?)))
+}
+
+pub fn router(inference: Arc<dyn Inference>) -> axum::Router {
+    axum::Router::new()
+        .route("/", post(predict))
+        .layer(Extension(inference))
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,34 @@
+use axum::response::IntoResponse;
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum DomainError {
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+    #[error("Process failed: {0}")]
+    ProcessFailed(String),
+    #[error("Inference failed: {0}")]
+    InferenceFailed(String),
+}
+
+impl IntoResponse for DomainError {
+    fn into_response(self) -> axum::response::Response {
+        let (status, message) = match &self {
+            DomainError::NotFound(msg) => (axum::http::StatusCode::NOT_FOUND, msg.to_string()),
+            DomainError::InvalidInput(msg) => {
+                (axum::http::StatusCode::BAD_REQUEST, msg.to_string())
+            }
+            DomainError::ProcessFailed(msg) => (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                msg.to_string(),
+            ),
+            DomainError::InferenceFailed(msg) => (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                msg.to_string(),
+            ),
+        };
+        let body = axum::Json(serde_json::json!({"error": message}));
+        (status, body).into_response()
+    }
+}

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,6 +1,44 @@
+use crate::errors::DomainError;
+use async_trait::async_trait;
+use ort::inputs;
 use ort::session::Session;
+use ort::value::{DynValue, Tensor};
+use std::sync::Arc;
 
 pub fn load_session(model_path: String) -> anyhow::Result<Session> {
     let session = Session::builder()?.commit_from_file(model_path)?;
     Ok(session)
+}
+
+#[async_trait]
+pub trait Inference: Send + Sync + 'static {
+    async fn infer(&self, input: Tensor<f32>) -> Result<Tensor<f32>, DomainError>;
+}
+
+pub struct InferenceImpl {
+    pub session: Arc<Session>,
+}
+
+#[async_trait]
+impl Inference for InferenceImpl {
+    async fn infer(&self, input: Tensor<f32>) -> Result<Tensor<f32>, DomainError> {
+        let mut outputs = self
+            .session
+            .run(inputs!(input).map_err(|e| {
+                eprintln!("Error during inference: {:?}", e);
+                DomainError::InferenceFailed(e.to_string())
+            })?)
+            .map_err(|e| {
+                eprintln!("Error during inference: {:?}", e);
+                DomainError::ProcessFailed(e.to_string())
+            })?;
+        let value: DynValue = outputs
+            .remove("Plus214_Output_0")
+            .ok_or_else(|| DomainError::InferenceFailed("Output not found".to_string()))?;
+
+        let tensor: Tensor<f32> = value
+            .downcast()
+            .map_err(|e| DomainError::InferenceFailed(format!("Failed to downcast: {:?}", e)))?;
+        Ok(tensor)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+mod api;
+mod errors;
 mod inference;
 mod models;
 
-use crate::inference::load_session;
+use crate::inference::{load_session, InferenceImpl};
 use axum::routing::get;
 use axum::Router;
 use ort::session::Session;
@@ -15,12 +17,16 @@ pub struct AppState {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let session = load_session("mnist-8.onnx".to_string())?;
-    let state = AppState {
-        session: Arc::new(session),
-    };
+    let session = Arc::new(load_session("mnist-8.onnx".to_string())?);
+    let inference = Arc::new(InferenceImpl {
+        session: session.clone(),
+    });
 
-    let app = Router::new().route("/", get(hello_world).fallback(get(anything_else)));
+    let app = Router::new()
+        .route("/", get(hello_world))
+        .nest("/predict", api::router(inference.clone()))
+        .fallback(get(anything_else));
+
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     let listener = TcpListener::bind(addr).await?;
     let _ = axum::serve(listener, app).await?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,29 +1,57 @@
+use crate::errors::DomainError;
+use ndarray::{ArrayD, ArrayViewD};
 use ort::value::Tensor;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Features {
     pub values: Vec<f32>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Prediction {
     pub values: Vec<f32>,
 }
 
 impl TryFrom<Features> for Tensor<f32> {
-    type Error = ();
+    type Error = DomainError;
 
     fn try_from(value: Features) -> Result<Self, Self::Error> {
-        let length = value.values.len();
-        if length != 728 {
-            return Err(());
+        let shape = vec![1, 1, 28, 28];
+        let flat_len: usize = shape.iter().product();
+
+        if value.values.len() != flat_len {
+            return Err(DomainError::InvalidInput(format!(
+                "expected {} floats, got {}",
+                flat_len,
+                value.values.len()
+            )));
         }
-        for i in value.values.iter() {
-            if *i < 0.0 || *i > 255.0 {
-                return Err(());
-            }
+
+        let arr = ArrayD::from_shape_vec(shape, value.values)
+            .map_err(|_| DomainError::InvalidInput("input shape is invalid".into()))?;
+        let tensor = Tensor::from_array(arr)
+            .map_err(|e| DomainError::ProcessFailed(format!("tensor creation error: {}", e)))?;
+        Ok(tensor)
+    }
+}
+
+impl TryFrom<Tensor<f32>> for Prediction {
+    type Error = DomainError;
+
+    fn try_from(value: Tensor<f32>) -> Result<Self, Self::Error> {
+        let arr: ArrayViewD<f32> = value.extract_tensor();
+        let shape = arr.shape();
+        let flat_len: usize = shape.iter().product();
+        let values: Vec<f32> = arr.iter().copied().collect();
+        if values.len() != flat_len {
+            return Err(DomainError::InvalidInput(format!(
+                "expected {} floats, got {}",
+                flat_len,
+                values.len()
+            )));
         }
-        Tensor::try_from(value)
+
+        Ok(Prediction { values })
     }
 }


### PR DESCRIPTION
This pull request introduces a new prediction API to the project, enabling inference using a pre-trained ONNX model. The changes include the addition of error handling, new data models, and a structured API endpoint. Below are the most important changes grouped by theme:

### API Implementation
* Added a `predict` function and a router in `src/api.rs` to handle prediction requests. The function processes input features, performs inference, and returns predictions as JSON.

### Error Handling
* Introduced a `DomainError` enum in `src/errors.rs` to standardize error handling, with variants for different error types (e.g., `NotFound`, `InvalidInput`, `InferenceFailed`). Implemented the `IntoResponse` trait to convert these errors into HTTP responses.

### Inference Logic
* Created an `Inference` trait in `src/inference.rs` for abstracting inference logic, and implemented it in the `InferenceImpl` struct. The implementation handles ONNX model inference and error propagation.

### Data Models
* Updated `Features` and `Prediction` structs in `src/models.rs` to support serialization/deserialization and added conversion logic between these structs and ONNX tensors, with validation for input shapes.

### Application Integration
* Modified `src/main.rs` to integrate the new API and inference logic. Replaced the previous `AppState` with an `InferenceImpl` instance and added a `/predict` endpoint to the router.