### PR TITLE
chore: add Dockerfile for containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/secrets.dev.yaml
+**/values.dev.yaml
+/bin
+/target
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+ARG RUST_VERSION=1.86.0
+ARG APP_NAME=rust-ml-inference-api
+
+FROM rust:${RUST_VERSION}-bookworm AS build
+ARG APP_NAME
+WORKDIR /app
+
+COPY ./onnx_models/mnist-8.onnx /bin/mnist-8.onnx
+
+RUN echo "deb http://deb.debian.org/debian unstable main" \
+      > /etc/apt/sources.list.d/unstable.list \
+ && printf "Package: libonnxruntime-dev\nPin: release a=unstable\nPin-Priority: 200\n" \
+      > /etc/apt/preferences.d/onnxruntime.pref \
+ && apt-get update
+
+RUN apt-get install -y --no-install-recommends \
+      clang \
+      lld \
+      pkg-config \
+      git \
+      libonnxruntime-dev/unstable \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN rm /etc/apt/sources.list.d/unstable.list
+
+
+RUN --mount=type=bind,source=src,target=src \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=cache,target=/app/target/ \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+cargo build --locked --release && \
+cp ./target/release/$APP_NAME /bin/server
+
+
+FROM debian:bookworm-slim AS final
+
+COPY --from=build /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/
+
+RUN ldconfig
+
+WORKDIR /app
+
+COPY --from=build /bin/mnist-8.onnx ./mnist-8.onnx
+COPY --from=build /bin/server    ./server
+
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+USER appuser
+
+EXPOSE 3000
+
+CMD ["./server"]

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,22 @@
+### Building and running your application
+
+When you're ready, start your application by running:
+`docker compose up --build`.
+
+Your application will be available at http://localhost:3000.
+
+### Deploying your application to the cloud
+
+First, build your image, e.g.: `docker build -t myapp .`.
+If your cloud uses a different CPU architecture than your development
+machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
+you'll want to build the image for that platform, e.g.:
+`docker build --platform=linux/amd64 -t myapp .`.
+
+Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail on building and pushing.
+
+### References
+* [Docker's Rust guide](https://docs.docker.com/language/rust/)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,50 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+services:
+  server:
+    build:
+      context: .
+      target: final
+    ports:
+      - 3000:3000
+
+# The commented out section below is an example of how to define a PostgreSQL
+# database that your application can use. `depends_on` tells Docker Compose to
+# start the database before your application. The `db-data` volume persists the
+# database data between container restarts. The `db-password` secret is used
+# to set the database password. You must create `db/password.txt` and add
+# a password of your choosing to it before running `docker compose up`.
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#   db:
+#     image: postgres
+#     restart: always
+#     user: postgres
+#     secrets:
+#       - db-password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+#     environment:
+#       - POSTGRES_DB=example
+#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+#     expose:
+#       - 5432
+#     healthcheck:
+#       test: [ "CMD", "pg_isready" ]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+# volumes:
+#   db-data:
+# secrets:
+#   db-password:
+#     file: db/password.txt
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/healthz", get(healthcheck))
         .nest("/predict", api::router(inference.clone()));
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
     let listener = TcpListener::bind(addr).await?;
     let _ = axum::serve(listener, app).await?;
     Ok(())


### PR DESCRIPTION
This pull request introduces Docker support for the Rust-based machine learning inference API, including containerization, deployment instructions, and related configuration updates. The most important changes involve creating Docker-related files, updating the server to listen on all network interfaces, and providing documentation for building and deploying the application.

### Docker support and containerization:
* Added a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, such as `node_modules`, `.git`, and temporary files.
* Created a `Dockerfile` to define a multi-stage build process for the Rust application, including dependencies for ONNX runtime and a final lightweight image for deployment.
* Added a `compose.yaml` file to define a Docker Compose service for the application, with instructions for exposing the server on port 3000.

### Documentation updates:
* Added `README.Docker.md` with instructions for building, running, and deploying the application using Docker, including platform-specific build guidance.

### Network configuration:
* Updated the server in `src/main.rs` to listen on all network interfaces (`0.0.0.0`) instead of just localhost (`127.0.0.1`) to allow external access when running in a container.